### PR TITLE
limit processing to events we actually listen for

### DIFF
--- a/clabot/github.py
+++ b/clabot/github.py
@@ -18,8 +18,14 @@ class AsyncWebhookView(BaseAsyncWebhookView):
     async def post(self, request: HttpRequest) -> JsonResponse:
         event = self.get_event(request)
 
-        event_log = await EventLog.objects.acreate_from_event(event)
-
-        await self.router.adispatch(event, None)
-
-        return self.get_response(event_log)
+        found_callbacks = self.router.fetch(event)
+        if found_callbacks:
+            event_log = await EventLog.objects.acreate_from_event(event)
+            await self.router.adispatch(event, None)
+            return self.get_response(event_log)
+        else:
+            return JsonResponse(
+                {
+                    "message": "ok",
+                }
+            )


### PR DESCRIPTION
by default, the webhook handler from django-github-app processes and stores all events, even if they are not registered as actionable.

since the Pull Request event on GitHub sends many events we are not interested in:

> Pull request assigned, auto merge disabled, auto merge enabled, closed, converted to draft, demilestoned, dequeued, edited, enqueued, labeled, locked, milestoned, opened, ready for review, reopened, review request removed, review requested, synchronized, unassigned, unlabeled, or unlocked.

This causes floods of events in situations like https://github.com/python/cpython/pull/132964 that we can skip the bulk of processing for.