### PR TITLE
don't instantiate the router on every request!

### DIFF
--- a/clabot/github.py
+++ b/clabot/github.py
@@ -6,6 +6,7 @@ from django.http import HttpRequest, JsonResponse
 from django_github_app._typing import override
 from django_github_app.github import AsyncGitHubAPI as BaseAsyncGitHubAPI
 from django_github_app.models import EventLog
+from django_github_app.routing import GitHubRouter
 from django_github_app.views import AsyncWebhookView as BaseAsyncWebhookView
 
 
@@ -17,6 +18,16 @@ class AsyncGitHubAPI(BaseAsyncGitHubAPI):
 
 class AsyncWebhookView(BaseAsyncWebhookView):
     github_api_class = AsyncGitHubAPI
+
+    @override
+    def __init__(self, **kwargs):
+        self._router = GitHubRouter(*GitHubRouter.routers)
+        return super().__init__(**kwargs)
+
+    @override
+    @property
+    def router(self):
+        return self._router
 
     @override
     async def post(self, request: HttpRequest) -> JsonResponse:


### PR DESCRIPTION
Upstream creates the gidgethub routing on each request, which leads to a cascading situation as found via Memray:

<img width="1270" alt="Screenshot 2025-05-01 at 12 15 09 PM" src="https://github.com/user-attachments/assets/4c24bdf7-dcee-4ca1-ab80-6043017b212c" />

This was causing memory consumption to grow out of control until the process was restarted via max_requests or OOM:

<img width="1091" alt="Screenshot 2025-05-01 at 11 16 10 AM" src="https://github.com/user-attachments/assets/9655122c-a34e-4573-959a-7289c345f096" />

Only instantiate the router once, on __init__ should fix it.