### PR TITLE
Update alt text for "CLA not signed" badge

### DIFF
--- a/cla/comments.py
+++ b/cla/comments.py
@@ -51,7 +51,7 @@ async def post_or_update_fail_comment(
         "The following commit authors need to sign "
         "the Contributor License Agreement:\n\n"
         f"{emails}\n\n"
-        f"[![CLA signed]({NOT_SIGNED_BADGE})]({settings.SITE_URL})"
+        f"[![CLA not signed]({NOT_SIGNED_BADGE})]({settings.SITE_URL})"
         f"{SENTINEL_MARKER}"
     )
     await post_or_update_comment(gh, message, target_repository_full_name, pull_request_number)


### PR DESCRIPTION
Currently, the alt text for both the signed and not-signed badges reads "CLA signed":

> <img width="789" height="455" alt="image" src="https://github.com/user-attachments/assets/4fac5b92-c005-4598-a7be-71c08f487501" />

This makes the alt text for the not-signed badge instead read "CLA not signed", like the badge text.

